### PR TITLE
Add AzureAd for Authentication

### DIFF
--- a/GacBootcampWebsite/Controllers/ADController.cs
+++ b/GacBootcampWebsite/Controllers/ADController.cs
@@ -1,13 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GacBootcampWebsite.Controllers
 {
+    [Authorize]
     public class ADController : Controller
     {
+        
         public IActionResult Index()
         {
             return View();

--- a/GacBootcampWebsite/GacBootcampWebsite.csproj
+++ b/GacBootcampWebsite/GacBootcampWebsite.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.9" />
   </ItemGroup>

--- a/GacBootcampWebsite/Startup.cs
+++ b/GacBootcampWebsite/Startup.cs
@@ -1,6 +1,11 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -18,7 +23,41 @@ namespace GacBootcampWebsite
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc()
+            services.AddAuthentication(AzureADDefaults.AuthenticationScheme)
+                .AddAzureAD(options => Configuration.Bind("AzureAd", options));
+
+            services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, options =>
+            {
+                options.Authority = options.Authority + "/v2.0/";
+
+                // Per the code below, this application signs in users in any Work and School
+                // accounts and any Microsoft Personal Accounts.
+                // If you want to direct Azure AD to restrict the users that can sign-in, change 
+                // the tenant value of the appsettings.json file in the following way:
+                // - only Work and School accounts => 'organizations'
+                // - only Microsoft Personal accounts => 'consumers'
+                // - Work and School and Personal accounts => 'common'
+
+                // If you want to restrict the users that can sign-in to only one tenant
+                // set the tenant value in the appsettings.json file to the tenant ID of this
+                // organization, and set ValidateIssuer below to true.
+
+                // If you want to restrict the users that can sign-in to several organizations
+                // Set the tenant value in the appsettings.json file to 'organizations', set
+                // ValidateIssuer, above to 'true', and add the issuers you want to accept to the
+                // options.TokenValidationParameters.ValidIssuers collection
+                options.TokenValidationParameters.ValidateIssuer = true;
+            });
+
+            services.AddMvc(options =>
+            {
+                // Add authentication to the entire site with the following:
+                //var policy = new AuthorizationPolicyBuilder()
+                //    .RequireAuthenticatedUser()
+                //    .Build();
+                //options.Filters.Add(new AuthorizeFilter(policy));
+                // To only add authentication on a specific controller use the [Authorize] attribute on it
+            })
                 .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
         }
 
@@ -36,6 +75,7 @@ namespace GacBootcampWebsite
             }
 
             app.UseStaticFiles();
+            app.UseAuthentication();
             app.UseMvc(routes =>
             {
                 routes.MapRoute(

--- a/GacBootcampWebsite/Views/Shared/_FooterPartial.cshtml
+++ b/GacBootcampWebsite/Views/Shared/_FooterPartial.cshtml
@@ -1,0 +1,18 @@
+﻿@using System.Security.Claims
+@{
+    var username = "";
+    if (User.Identity.IsAuthenticated)
+    {
+        var identity = User.Identity as ClaimsIdentity; // Azure AD V2 endpoint specific
+        username = identity.Claims.FirstOrDefault(c => c.Type == "preferred_username")?.Value;
+    }
+}
+
+@if (string.IsNullOrEmpty(username) == false)
+{
+    <div style="position:fixed;height:50px;padding:5px;font-size:20px;left:0;bottom:0;text-align:center;width:100%;background-color:aqua">
+        <form asp-controller="AD" asp-action="Logout" method="post">
+            Logged in as: @username &nbsp;<a asp-area="AzureAD" asp-controller="Account" asp-action="SignOut">Sign out</a>
+        </form>
+    </div>
+}

--- a/GacBootcampWebsite/Views/Shared/_Layout.cshtml
+++ b/GacBootcampWebsite/Views/Shared/_Layout.cshtml
@@ -1,4 +1,5 @@
-﻿<!DOCTYPE html>
+﻿
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />
@@ -77,5 +78,7 @@
     </environment>
 
     @RenderSection("Scripts", required: false)
+    
+    <partial name="_FooterPartial" />
 </body>
 </html>

--- a/GacBootcampWebsite/appsettings.json
+++ b/GacBootcampWebsite/appsettings.json
@@ -1,4 +1,11 @@
 {
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "Domain": "ellasta.onmicrosoft.com",
+    "TenantId": "725be0ce-2b76-471d-b553-512e1d9e9492",
+    "ClientId": "c225b06e-aca0-4896-b5ec-25efe0011ec1",
+    "CallbackPath": "/signin-oidc"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Warning"


### PR DESCRIPTION
This assignment consists of two things
1. Create a Azure Active Directory
2. Enable authentication on your website, that is managed via Azure AD

# Create a Azure Active Directory

The span of this assignment depends on your current Azure account setup. It might already be part of a Azure Active Directory, then we need to ensure that you have access to it. Else, Creat a new one :-)
Creation should be done via the Azure Portal, pick a name for it, the url will be name.onmicrosoft.com.

# Create a Service Principal (App registration) that can access the Azure AD
In the Azure Portal, you should go to the Active Directory, and find the pane called `App Registrations(Preview)`, then add a new registration.

Within this registration fill the following:
Name: pick a good one :-)
Supported Account types: Accounts in this organizational directory only (name) <- this will ensure that only users created in this directory can access it.
Redirect url: the url your app is running localhost, mine was `https://localhost:44384/`

After registering, go to the Authentication,
in Redirect URIs add `https://localhost:44321/signin-oidc`
Implicit grant, check `ID tokens`.
Save

What have we done now? We have registered an application, which will be our website, and allowed it to authenticate to our Active Directory. Your own user should automatically be added, and you can use it to authenticate, when needed.

Next up is setting up the webapplication to use the identity, and authenticate against our Active Directory.

# Setup Code
To implement the authentication we have 4 steps to go through
1. Add the nuget package
`Microsoft.AspNetCore.Authentication.AzureAD.UI` - use version `2.1.1`as its compatible with .net core 2.1 which our app is running.

2. Update Startup.cs
Once added we need to hook into the `Startup.cs` class, and the `ConfigureServices` method
```
    // Add the authentication, and read the section "AzureAd" from the appsettings.json
    services.AddAuthentication(AzureADDefaults.AuthenticationScheme)
                .AddAzureAD(options => Configuration.Bind("AzureAd", options));

    // Configure OpenIdConnect options, which we are using for authentication
    services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, options =>
            {
                options.Authority = options.Authority + "/v2.0/";
                options.TokenValidationParameters.ValidateIssuer = true;
            });
```

In the `Configure` method, add `app.UseAuthentication()` which allows the app to use the authentication.

3. Update appsettings.json
`appsettings.json` needs to be updated with a AzureAd section, where we enter settings from our App registration, mine looks like the following, find them in the Azure Active Directory:
```
"AzureAd": {
    "Instance": "https://login.microsoftonline.com/",
    "Domain": "name.onmicrosoft.com",
    "TenantId": "725be0ce-2b76-471d-b553-512e1d9e9492", //Azure AD tenant
    "ClientId": "c225b06e-aca0-4896-b5ec-25efe0011ec1", // Application registration id
    "CallbackPath": "/signin-oidc"
  }
```

4. Add Autorized to a controller
Now we have setup everything, but nothing has been set to require authentication. This can be done on multiple levels. 
- Entire Application - means all requests will need to be requested
- A single Controller, ie. everything in /AD
- A single action, i.e. /Ad/Index

In this PR we just set it on the ADController, by decorating it with the Autorize attribute

```
    [Authorize]
    public class ADController : Controller
```

Thats it, now we are done, run the site, one it runs, to to the /Ad url, and you should be redirected to a login page at Microsoft to login.

Docs:
https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-v2-aspnet-core-webapp

If you look at the PR, I've created a LogedIn partial, where we can recieve the username from AD, and display it, as well as a logout button, check the `_FooterPartial.cshtml` file